### PR TITLE
Allow to use "uws job phase <jobid>" to request the job phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,16 @@ corresponding phase
 Job handling:
 -------------
 
-usage: `uws job [-h] {set,run,show,results,abort,new,delete} ...`  
+usage: `uws job [-h] {set,run,show,phase,results,abort,new,delete} ...`  
 
 positional arguments:  
-  {`set`,`run`,`show`,`results`,`abort`,`new`,`delete`}
+  {`set`,`run`,`show`,`phase`,`results`,`abort`,`new`,`delete`}
                           commands for manipulating jobs  
     `show`                show the specific job  
     `new`                 create a new job  
     `set`                 set parameters for the specific job  
-    `run`                 run the specific job if its state is pending  
+    `run`                 run the specific job if its state is pending
+    `phase`               show the phase of a specific job
     `abort`               aborts the execution of a specific job  
     `delete`              delete a specific job  
     `results`             download results of a specific job  
@@ -175,6 +176,18 @@ Run / submit an existing job:
 -----------------------------
 
 usage: `uws job run [-h] id`  
+
+positional arguments:  
+  `id`          `job id`
+
+optional arguments:  
+  `-h`, `--help`  show this help message and exit
+
+
+Show phase of job:
+------------------
+
+usage: `uws job phase [-h] id`
 
 positional arguments:  
   `id`          `job id`

--- a/uws/UWS/base.py
+++ b/uws/UWS/base.py
@@ -48,17 +48,9 @@ class BaseUWSClient(object):
             raise UWSError(str(e))
 
         raw = response.read()
-        # response is only the phase name, there is exactly one phase per job, 
-        # so just use this here.
-        try:
-            result = raw
-        except XMLSyntaxError as e:
-            raise UWSError("Malformatted response. Are you sure the host you specified is a IVOA UWS service?", raw)
-        except Exception as e:
-            raise e
-
+        result = raw
+        
         return result
-
 
     def new_job(self, args={}):
         try:

--- a/uws/UWS/base.py
+++ b/uws/UWS/base.py
@@ -41,6 +41,25 @@ class BaseUWSClient(object):
 
         return result
 
+    def get_phase(self, id):
+        try:
+            response = self.connection.get(id + '/phase')
+        except Exception as e:
+            raise UWSError(str(e))
+
+        raw = response.read()
+        # response is only the phase name, there is exactly one phase per job, 
+        # so just use this here.
+        try:
+            result = raw
+        except XMLSyntaxError as e:
+            raise UWSError("Malformatted response. Are you sure the host you specified is a IVOA UWS service?", raw)
+        except Exception as e:
+            raise e
+
+        return result
+
+
     def new_job(self, args={}):
         try:
             response = self.connection.post('', args)

--- a/uws/cli/cli_parser.py
+++ b/uws/cli/cli_parser.py
@@ -39,6 +39,10 @@ def build_job_argparse(subparsers):
     parser_job_show = job_subparsers.add_parser('show', help='show the specific job')
     parser_job_show.add_argument('id', help='job id')
 
+    parser_job_phase = job_subparsers.add_parser('phase', help='show the phase of specific job')
+    parser_job_phase.add_argument('id', help='job id')
+
+
     parser_job_new = job_subparsers.add_parser('new', help='create a new job')
     parser_job_new.add_argument('-r', '--run', action='store_true', help='immediately submits the job on creation')
     parser_job_new.add_argument('job_parameters', nargs='*', help='unspecified list of UWS service parameters in the form' +

--- a/uws/cli/main.py
+++ b/uws/cli/main.py
@@ -102,6 +102,16 @@ def show_job(url, user_name, password, id):
 
 
 @handle_error
+def show_phase(url, user_name, password, id):
+    uws_connection = UWS.connection.Connection(url, user_name, password)
+    uws_client = UWS.base.BaseUWSClient(uws_connection)
+
+    phase = uws_client.get_phase(id)
+
+    print(phase)
+
+
+@handle_error
 def new_job(url, user_name, password, parameters={}, run=False):
     uws_connection = UWS.connection.Connection(url, user_name, password)
     uws_client = UWS.base.BaseUWSClient(uws_connection)
@@ -331,6 +341,8 @@ def main():
     if arguments.command == "job":
         if arguments.job_command == "show":
             show_job(arguments.host, arguments.user, arguments.password, arguments.id)
+        elif arguments.job_command == "phase":
+            show_phase(arguments.host, arguments.user, arguments.password, arguments.id)
         elif arguments.job_command == "new":
             # parse the job parameters and store in argument list
             job_parameters = _check_job_parameter_args(arguments.job_parameters)


### PR DESCRIPTION
Added additional option to request just for the phase of a job using:

`uws job phase <jobid>`

We don't have to return an array of phases, since each job should have only exactly one ExecutionPhase according to section [2.1.2 Job](http://www.ivoa.net/documents/UWS/20150626/PR-UWS-1.1-20150626.html#Job) in the UWS standard.