### PR TITLE
WAIT parameter for UWS 1.1 blocking behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ List all jobs on service:
 -------------------------
 
 usage: `uws list [-h] [-c] [-p] [-q] [-e] [-E] [-a] [--unknown] [--held]
-                   [--suspended]`
+                   [--suspended] [--archived]`
 
 optional arguments:  
   `-h`, `--help`       show this help message and exit  
@@ -86,6 +86,7 @@ optional arguments:
   `--unknown`          show unknown state jobs  
   `--held`             show held jobs  
   `--suspended`        show suspended jobs  
+  `--archived`         [UWS1.1] show (deleted) jobs archived on the server
 
 
 Specifying any of the specific job phases will only show those jobs with the
@@ -116,13 +117,15 @@ optional arguments:
 Show job:
 ---------
 
-usage: `uws job show [-h] id`
+usage: `uws job show [-h] id [-w [WAIT]] [-s PHASE] `
 
 positional arguments:  
   `id`          `job id`
 
 optional arguments:  
-  `-h`, `--help`  show this help message and exit
+  `-h`, `--help`                show this help message and exit  
+  `-w [WAIT]`, `--wait [WAIT]`  [UWS1.1] wait for phase change before returning, but at most the specified amount of seconds or infinitely, if no value is given  
+  `-s PHASE`, `--phase PHASE`   [UWS1.1] required phase while waiting  
 
 
 New job:

--- a/uws/UWS/client.py
+++ b/uws/UWS/client.py
@@ -56,12 +56,13 @@ class Client(object):
         return params
 
     def _validate_and_parse_wait(self, wait, phase=None):
-        try:
+        # wait must be positive integer or -1
+        if wait.isdigit() or wait == '-1':
             duration = int(wait)
-        except:
-            raise UWSError("Value for wait-keyword must be integer: %s" % str(wait))
+        else:
+            raise UWSError("Value for wait-keyword must be positive integer or -1: %s" % str(wait))
 
-        params = [("WAIT", wait)]
+        params = [("WAIT", duration)]
 
         if phase:
             if phase not in models.JobPhases.active_phases:
@@ -74,8 +75,6 @@ class Client(object):
         params = None
         if wait:
             params = self._validate_and_parse_wait(wait, phase)
-
-        print 'params: ', wait, phase, params
 
         try:
             response = self.connection.get(id, params)

--- a/uws/UWS/models.py
+++ b/uws/UWS/models.py
@@ -48,6 +48,9 @@ class JobPhases(object):
               ERROR, ABORTED, UNKNOWN, HELD,
               SUSPENDED, ARCHIVED]
 
+    # phases for which blocking behaviour can occur:
+    active_phases = [PENDING, QUEUED, EXECUTING]
+
     versions = {
         COMPLETED: ['1.0', '1.1'],
         PENDING: ['1.0', '1.1'],

--- a/uws/UWS/tests/test_base.py
+++ b/uws/UWS/tests/test_base.py
@@ -25,23 +25,38 @@ class BaseTest(unittest.TestCase):
             filters
         )
 
+    def testValidateAndParseWaitNegative(self):
+        wait = '-1'
+        params = UWS.client.Client("/")._validate_and_parse_wait(wait)
+
+        self.assertEqual(params, [('WAIT', -1)])
+
     def testValidateAndParseWait(self):
-        wait = 30
+        wait = '30'
         params = UWS.client.Client("/")._validate_and_parse_wait(wait)
 
         self.assertEqual(params, [('WAIT', 30)])
 
     def testValidateAndParseWaitInvalidWait(self):
-        wait = 30.587
+        wait = '30.587'
 
         self.assertRaises(
             UWS.UWSError,
             UWS.client.Client("/")._validate_and_parse_wait,
-            [wait]
+            wait
+        )
+
+    def testValidateAndParseWaitInvalidWaitNegative(self):
+        wait = '-30'
+
+        self.assertRaises(
+            UWS.UWSError,
+            UWS.client.Client("/")._validate_and_parse_wait,
+            wait
         )
 
     def testValidateAndParseWaitPhase(self):
-        wait = 30
+        wait = '30'
         phase = 'EXECUTING'
 
         params = UWS.client.Client("/")._validate_and_parse_wait(wait, phase)
@@ -49,11 +64,11 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(params, [('WAIT', 30), ('PHASE', 'EXECUTING')])
 
     def testValidateAndParseWaitInvalidPhase(self):
-        wait = 15
+        wait = '15'
         phase = 'COMPLETED'
 
         self.assertRaises(
             UWS.UWSError,
             UWS.client.Client("/")._validate_and_parse_wait,
-            [wait, phase]
+            wait, phase
         )

--- a/uws/UWS/tests/test_base.py
+++ b/uws/UWS/tests/test_base.py
@@ -24,3 +24,36 @@ class BaseTest(unittest.TestCase):
             UWS.client.Client("/")._validate_and_parse_filters,
             filters
         )
+
+    def testValidateAndParseWait(self):
+        wait = 30
+        params = UWS.client.Client("/")._validate_and_parse_wait(wait)
+
+        self.assertEqual(params, [('WAIT', 30)])
+
+    def testValidateAndParseWaitInvalidWait(self):
+        wait = 30.587
+
+        self.assertRaises(
+            UWS.UWSError,
+            UWS.client.Client("/")._validate_and_parse_wait,
+            [wait]
+        )
+
+    def testValidateAndParseWaitPhase(self):
+        wait = 30
+        phase = 'EXECUTING'
+
+        params = UWS.client.Client("/")._validate_and_parse_wait(wait, phase)
+
+        self.assertEqual(params, [('WAIT', 30), ('PHASE', 'EXECUTING')])
+
+    def testValidateAndParseWaitInvalidPhase(self):
+        wait = 15
+        phase = 'COMPLETED'
+
+        self.assertRaises(
+            UWS.UWSError,
+            UWS.client.Client("/")._validate_and_parse_wait,
+            [wait, phase]
+        )

--- a/uws/cli/cli_parser.py
+++ b/uws/cli/cli_parser.py
@@ -39,10 +39,14 @@ def build_job_argparse(subparsers):
     job_subparsers = parser_job.add_subparsers(dest='job_command', help='commands for manipulating jobs')
     parser_job_show = job_subparsers.add_parser('show', help='show the specific job')
     parser_job_show.add_argument('id', help='job id')
+    parser_job_show.add_argument('-w', '--wait', nargs='?', const=-1, default=None, help='wait for phase change before returning, but at most the specified amount of seconds or infinitely, if no value is given')
+    # parser_job_show.add_argument('-s', '--phase', help='required phase while waiting')
+    parser_job_show.add_argument('-p', '--pending', action='store_true', help='only wait if job is in pending phase')
+    parser_job_show.add_argument('-q', '--queued', action='store_true', help='only wait if job is in queued phase')
+    parser_job_show.add_argument('-e', '--executing', action='store_true', help='only wait if job is in executing phase')
 
     parser_job_phase = job_subparsers.add_parser('phase', help='show the phase of specific job')
     parser_job_phase.add_argument('id', help='job id')
-
 
     parser_job_new = job_subparsers.add_parser('new', help='create a new job')
     parser_job_new.add_argument('-r', '--run', action='store_true', help='immediately submits the job on creation')

--- a/uws/cli/cli_parser.py
+++ b/uws/cli/cli_parser.py
@@ -40,10 +40,7 @@ def build_job_argparse(subparsers):
     parser_job_show = job_subparsers.add_parser('show', help='show the specific job')
     parser_job_show.add_argument('id', help='job id')
     parser_job_show.add_argument('-w', '--wait', nargs='?', const=-1, default=None, help='wait for phase change before returning, but at most the specified amount of seconds or infinitely, if no value is given')
-    # parser_job_show.add_argument('-s', '--phase', help='required phase while waiting')
-    parser_job_show.add_argument('-p', '--pending', action='store_true', help='only wait if job is in pending phase')
-    parser_job_show.add_argument('-q', '--queued', action='store_true', help='only wait if job is in queued phase')
-    parser_job_show.add_argument('-e', '--executing', action='store_true', help='only wait if job is in executing phase')
+    parser_job_show.add_argument('-s', '--phase', help='required phase while waiting')
 
     parser_job_phase = job_subparsers.add_parser('phase', help='show the phase of specific job')
     parser_job_phase.add_argument('id', help='job id')

--- a/uws/cli/main.py
+++ b/uws/cli/main.py
@@ -102,6 +102,9 @@ def show_job(url, user_name, password, id, wait, phase):
 
     job = uws_client.get_job(id, wait, phase)
 
+    if wait and job.version != "1.1":
+        print "Warning: Wait keyword is (probably) not supported by the server's UWS version %s (need 1.1). Server will probably return immediately, wait is ignored." % job.version
+
     _print_job(job)
 
 


### PR DESCRIPTION
This includes the additional optional parameter "--wait" for `uws job show` that can be used when requesting job details from a UWS1.1 server. The server is expected to block and return if
a) the job changed its phase
b) the specified time is over 
c) the server times out or stops blocking for some other reason (e.g. too many blocking requests)

If additionally a phase is given with "--executing", "--queued" or "--pending" (nothing else allowed), then server should return immediately, if the job is *not* in the specified phase.
See section 2.2.1.2 Blocking Behaviour of the [UWS standard](http://www.ivoa.net/documents/UWS/20150907/PR-UWS-1.1-20150907.pdf).

Example:
`uws job show [id] --wait 30 --executing`
Waits for 30 seconds for the job with id [id], but returns immediately if phase of job is not executing.
