### PR TITLE
Trouble with reusing connection - CannotSendRequest()

### DIFF
--- a/uws/UWS/client.py
+++ b/uws/UWS/client.py
@@ -20,7 +20,9 @@ class Client(object):
 
         try:
             response = self.connection.get('', params)
-        except:
+        except Exception as e1:
+            print 'Warning: GET request for job list failed with error: \n    %s' % (str(e1))
+            print 'Retrying now without any parameters.'
             # PROBLEM: calling self.connection.get() a second time and reusing the connection 
             # without calling a getresponse() or close() or something beforehand, 
             # will lead to a httplib CannotSendRequest() error!

--- a/uws/UWS/client.py
+++ b/uws/UWS/client.py
@@ -20,16 +20,13 @@ class Client(object):
 
         try:
             response = self.connection.get('', params)
-        except Exception as e1:
-            print 'Warning: GET request for job list failed with error: \n    %s' % (str(e1))
-            print 'Retrying now without any parameters.'
-            # PROBLEM: calling self.connection.get() a second time and reusing the connection 
-            # without calling a getresponse() or close() or something beforehand, 
-            # will lead to a httplib CannotSendRequest() error!
-            try:
-                response = self.connection.get('')
-            except Exception as e:
-                raise UWSError(str(e))
+        except Exception as e:
+            # Do not try to make a seconds request without parameters here, 
+            # because cannot call self.connection.get() a second time and reusing the connection 
+            # without calling a getresponse() or close() or something beforehand.
+            # (This would lead to a httplib CannotSendRequest() error!)
+            # Let's just raise the error immediately.
+            raise UWSError(str(e))
 
         raw = response.read()
 

--- a/uws/UWS/client.py
+++ b/uws/UWS/client.py
@@ -21,7 +21,9 @@ class Client(object):
         try:
             response = self.connection.get('', params)
         except:
-            # TODO: put a warning here that parameters are going to be ignored!
+            # PROBLEM: calling self.connection.get() a second time and reusing the connection 
+            # without calling a getresponse() or close() or something beforehand, 
+            # will lead to a httplib CannotSendRequest() error!
             try:
                 response = self.connection.get('')
             except Exception as e:


### PR DESCRIPTION
I finally know where the problem with missing error messages comes from, when requesting the job list (e.g. if typo in host name or authentication missing). 

If an error occurs in get_job_list in uws/UWS/client.py, then a second try is made without parameters. But this results in a httplib CannotSendRequest(), because the connection cannot be used twice for a request. One needs to first use getresponse() or close() or create a new connection each time, also see answer at http://stackoverflow.com/questions/5346434/python-cannotsendrequest. 

This should be fixed soon, or we just don't call a second time but raise the error immediately.