### PR TITLE
Accept redirects with HTTP 303 code

### DIFF
--- a/uws/UWS/connection.py
+++ b/uws/UWS/connection.py
@@ -53,7 +53,7 @@ class Connection(object):
 
         response = self.connection.getresponse()
 
-        if response.status == 302:
+        if response.status == 302 or response.status == 303:
             # found - redirect
             location = response.getheader("location")
             new_base_path = location.replace(path, '').lstrip("/")


### PR DESCRIPTION
DaCHS UWS server mostly uses HTTP 303 redirects which for the moment is not compatible with uws-client and gives UWSerror